### PR TITLE
fix: remove temporary color change code from CartDrawer

### DIFF
--- a/assets/cart-drawer.js
+++ b/assets/cart-drawer.js
@@ -45,16 +45,6 @@ class CartDrawer extends HTMLElement {
     );
 
     document.body.classList.add('overflow-hidden');
-    
-    // *** custom code
-    const drawerHeading = this.querySelector('.drawer__heading');
-    setTimeout(function(){
-      drawerHeading.style.color = 'red';
-    }, 3000);
-    setTimeout(function(){
-      drawerHeading.style.color = 'white';
-    }, 6000);
-    // *** custom code ends
   }
 
   close() {


### PR DESCRIPTION
This is a simple troubleshooting exercise created by the instructor of the tutorial.